### PR TITLE
Fix SSL failure of pubtools-sign appimage

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,7 +1,8 @@
 version: 1
 script:
-  # Install dependency which is required by appimagebuilder 
-  - apt install -y squashfs-tools
+  # Install dependency which is required by appimagebuilder
+  - apt-get update
+  - apt install -y squashfs-tools libssl-dev
   # Remove any previous build
   - rm -rf AppDir  | true
   # Make usr and icons dirs


### PR DESCRIPTION
Add installing libssl-dev in the appimage to avoid the failure.

Refer to CLOUDDST-20144