### PR TITLE
Support raw output for cli

### DIFF
--- a/src/pubtools/sign/signers/msgsigner.py
+++ b/src/pubtools/sign/signers/msgsigner.py
@@ -475,12 +475,16 @@ def msg_clear_sign_main(inputs, signing_key=None, task_id=None, config=None, raw
     ret = msg_clear_sign(inputs, signing_key=signing_key, task_id=task_id, config=config)
     if not raw:
         click.echo(json.dumps(ret))
-    if ret["signer_result"]["status"] == "error":
-        print(ret["signer_result"]["error_message"], file=sys.stderr)
-        sys.exit(1)
+        print(ret)
+        if ret["signer_result"]["status"] == "error":
+            sys.exit(1)
     else:
-        for claim in ret["operation_results"]:
-            print(claim)
+        if ret["signer_result"]["status"] == "error":
+            print(ret["signer_result"]["error_message"], file=sys.stderr)
+            sys.exit(1)
+        else:
+            for claim in ret["operation_results"]:
+                print(claim)
 
 
 @click.command()
@@ -519,6 +523,8 @@ def msg_container_sign_main(
     )
     if not raw:
         click.echo(json.dumps(ret))
+        if ret["signer_result"]["status"] == "error":
+            sys.exit(1)
     else:
         if ret["signer_result"]["status"] == "error":
             print(ret["signer_result"]["error_message"], file=sys.stderr)

--- a/src/pubtools/sign/signers/msgsigner.py
+++ b/src/pubtools/sign/signers/msgsigner.py
@@ -8,6 +8,7 @@ import logging
 from typing import Dict, List, ClassVar, Any, Optional
 import uuid
 import os
+import sys
 
 import OpenSSL
 import click
@@ -467,12 +468,19 @@ def msg_container_sign(signing_key=None, task_id=None, config="", digest=None, r
 )
 @click.option("--task-id", required=True, help="Task id identifier (usually pub task-id)")
 @click.option("--config", default=CONFIG_PATHS[0], help="path to the config file")
+@click.option("--raw", default=False, is_flag=True, help="Print raw output instead of json")
 @click.argument("inputs", nargs=-1)
-def msg_clear_sign_main(inputs, signing_key=None, task_id=None, config=None):
+def msg_clear_sign_main(inputs, signing_key=None, task_id=None, config=None, raw=None):
     """Entry point method for clearsign operation."""
-    click.echo(
-        json.dumps(msg_clear_sign(inputs, signing_key=signing_key, task_id=task_id, config=config))
-    )
+    ret = msg_clear_sign(inputs, signing_key=signing_key, task_id=task_id, config=config)
+    if not raw:
+        click.echo(json.dumps(ret))
+    if ret["signer_result"]["status"] == "error":
+        print(ret["signer_result"]["error_message"], file=sys.stderr)
+        sys.exit(1)
+    else:
+        for claim in ret["operation_results"]:
+            print(claim)
 
 
 @click.command()
@@ -497,18 +505,24 @@ def msg_clear_sign_main(inputs, signing_key=None, task_id=None, config=None):
     type=str,
     help="References which should be signed.",
 )
+@click.option("--raw", default=False, is_flag=True, help="Print raw output instead of json")
 def msg_container_sign_main(
-    signing_key=None, task_id=None, config=None, digest=None, reference=None
+    signing_key=None, task_id=None, config=None, digest=None, reference=None, raw=None
 ):
     """Entry point method for containersign operation."""
-    click.echo(
-        json.dumps(
-            msg_container_sign(
-                signing_key=signing_key,
-                task_id=task_id,
-                config=config,
-                digest=digest,
-                reference=reference,
-            )
-        )
+    ret = msg_container_sign(
+        signing_key=signing_key,
+        task_id=task_id,
+        config=config,
+        digest=digest,
+        reference=reference,
     )
+    if not raw:
+        click.echo(json.dumps(ret))
+    else:
+        if ret["signer_result"]["status"] == "error":
+            print(ret["signer_result"]["error_message"], file=sys.stderr)
+            sys.exit(1)
+        else:
+            for claim in ret["operation_results"]:
+                print(claim)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -4,7 +4,9 @@ from pubtools.sign.bundle import cli
 
 
 def test_bundle_msg_container_sign(f_msg_signer, f_config_msg_signer_ok):
-    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {}
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
     f_msg_signer.return_value.sign.return_value.operation_result.signed_claims = []
     f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
     result = CliRunner().invoke(
@@ -27,7 +29,9 @@ def test_bundle_msg_container_sign(f_msg_signer, f_config_msg_signer_ok):
 
 
 def test_bundle_msg_clear_sign(f_msg_signer, f_config_msg_signer_ok):
-    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {}
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
     f_msg_signer.return_value.sign.return_value.operation_result.outputs = []
     f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
     result = CliRunner().invoke(

--- a/tests/test_msg_signer.py
+++ b/tests/test_msg_signer.py
@@ -28,7 +28,9 @@ from pubtools.sign.results.signing_results import SigningResults
 
 
 def test_msg_container_sign(f_msg_signer, f_config_msg_signer_ok):
-    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {}
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
     f_msg_signer.return_value.sign.return_value.operation_result.signed_claims = []
     f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
     result = CliRunner().invoke(
@@ -48,6 +50,32 @@ def test_msg_container_sign(f_msg_signer, f_config_msg_signer_ok):
     )
     print(result.stdout)
     assert result.exit_code == 0, result.output
+
+
+def test_msg_container_sign_error(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "error",
+        "error_message": "simulated error",
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.signed_claims = []
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    result = CliRunner().invoke(
+        msg_container_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--digest",
+            "some-digest",
+            "--reference",
+            "some-reference",
+            "--task-id",
+            "1",
+            "--config",
+            f_config_msg_signer_ok,
+        ],
+    )
+    print(result.stdout)
+    assert result.exit_code == 1, result.output
 
 
 def test_msg_container_sign_raw(f_msg_signer, f_config_msg_signer_ok):
@@ -126,6 +154,28 @@ def test_msg_clearsign_sign(f_msg_signer, f_config_msg_signer_ok):
     assert result.exit_code == 0, result.output
 
 
+def test_msg_clearsign_sign_error(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "error",
+        "error_message": "simulated error",
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.outputs = []
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    result = CliRunner().invoke(
+        msg_clear_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--task-id",
+            "1",
+            "--config",
+            f_config_msg_signer_ok,
+            "hello world",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+
+
 def test_msg_clearsign_sign_raw(f_msg_signer, f_config_msg_signer_ok):
     f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
         "status": "ok"
@@ -149,7 +199,7 @@ def test_msg_clearsign_sign_raw(f_msg_signer, f_config_msg_signer_ok):
     assert result.output == "signed\n"
 
 
-def test_msg_clearsign_sign_error(f_msg_signer, f_config_msg_signer_ok):
+def test_msg_clearsign_sign_raw_error(f_msg_signer, f_config_msg_signer_ok):
     f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
         "status": "error",
         "error_message": "simulated error",

--- a/tests/test_msg_signer.py
+++ b/tests/test_msg_signer.py
@@ -50,8 +50,65 @@ def test_msg_container_sign(f_msg_signer, f_config_msg_signer_ok):
     assert result.exit_code == 0, result.output
 
 
+def test_msg_container_sign_raw(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.signed_claims = ["signed"]
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    result = CliRunner().invoke(
+        msg_container_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--digest",
+            "some-digest",
+            "--reference",
+            "some-reference",
+            "--task-id",
+            "1",
+            "--config",
+            f_config_msg_signer_ok,
+            "--raw",
+        ],
+    )
+    print(result.stdout)
+    assert result.exit_code == 0, result.output
+    assert result.output == "signed\n"
+
+
+def test_msg_container_sign_raw_error(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "error",
+        "error_message": "simulated error",
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.signed_claims = []
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    result = CliRunner().invoke(
+        msg_container_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--digest",
+            "some-digest",
+            "--reference",
+            "some-reference",
+            "--task-id",
+            "1",
+            "--config",
+            f_config_msg_signer_ok,
+            "--raw",
+        ],
+    )
+    print(result.stdout)
+    assert result.exit_code == 1, result.output
+    assert result.output == "simulated error\n"
+
+
 def test_msg_clearsign_sign(f_msg_signer, f_config_msg_signer_ok):
-    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {}
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
     f_msg_signer.return_value.sign.return_value.operation_result.outputs = []
     f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
     result = CliRunner().invoke(
@@ -69,8 +126,58 @@ def test_msg_clearsign_sign(f_msg_signer, f_config_msg_signer_ok):
     assert result.exit_code == 0, result.output
 
 
+def test_msg_clearsign_sign_raw(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.outputs = ["signed"]
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    result = CliRunner().invoke(
+        msg_clear_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--task-id",
+            "1",
+            "--config",
+            f_config_msg_signer_ok,
+            "--raw",
+            "hello world",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == "signed\n"
+
+
+def test_msg_clearsign_sign_error(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "error",
+        "error_message": "simulated error",
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.outputs = []
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    result = CliRunner().invoke(
+        msg_clear_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--task-id",
+            "1",
+            "--config",
+            f_config_msg_signer_ok,
+            "--raw",
+            "hello world",
+        ],
+    )
+    print(result.stdout)
+    assert result.exit_code == 1, result.output
+    assert result.output == "simulated error\n"
+
+
 def test_msg_clearsign_sign_file_input(f_msg_signer, f_config_msg_signer_ok):
-    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {}
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
     f_msg_signer.return_value.sign.return_value.operation_result.outputs = []
     f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
     result = CliRunner().invoke(


### PR DESCRIPTION
When --raw is specified, signed messages are printed to stdout. In the case of failure, error_message from signer result is printed to stderr and 1 is returned as exit code