### PR TITLE
Add static typing to pubtools-sign

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -59,6 +59,22 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e docs -vv
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update existing dependencies
+        run: sudo apt-get update -y
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e mypy -vv
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -87,7 +103,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.7
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+disallow_subclassing_any = False
+strict = True

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,7 @@ bandit
 sphinx
 ansible
 requests_mock
+mypy
+types-requests
+types-pyOpenSSL
+types-PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 typing_extension
 
-

--- a/src/pubtools/sign/ansible/msg_clear_sign.py
+++ b/src/pubtools/sign/ansible/msg_clear_sign.py
@@ -64,7 +64,7 @@ RETURN = r"""
 )
 
 
-def run_module():
+def run_module() -> None:
     """Run clearsign module."""
     # Define available arguments/parameters a user can pass to the module
     module_args = dict(

--- a/src/pubtools/sign/bundle.py
+++ b/src/pubtools/sign/bundle.py
@@ -6,7 +6,7 @@ from .signers.cosignsigner import cosign_container_sign_main
 
 
 @click.group()
-def cli():
+def cli() -> None:
     """Pubtools-sign multi command bundle."""
     pass
 

--- a/src/pubtools/sign/clients/msg.py
+++ b/src/pubtools/sign/clients/msg.py
@@ -1,14 +1,17 @@
+from typing import Any, List
+
 from ..models.msg import MsgError
 
 from proton.handlers import MessagingHandler
+import proton
 
 
 class _MsgClient(MessagingHandler):
-    def __init__(self, errors):
+    def __init__(self, errors: List[MsgError]) -> None:
         super().__init__()
         self.errors = errors
 
-    def on_error(self, event, source=None):
+    def on_error(self, event: proton.Event, source: Any = None) -> None:
         self.errors.append(
             MsgError(
                 name=event,
@@ -18,14 +21,14 @@ class _MsgClient(MessagingHandler):
         )
         event.container.stop()
 
-    def on_link_error(self, event):
+    def on_link_error(self, event: proton.Event) -> None:
         self.on_error(event, event.link)
 
-    def on_session_error(self, event):
+    def on_session_error(self, event: proton.Event) -> None:
         self.on_error(event, event.session)
 
-    def on_connection_error(self, event):
+    def on_connection_error(self, event: proton.Event) -> None:
         self.on_error(event, event.connection)
 
-    def on_transport_error(self, event):
+    def on_transport_error(self, event: proton.Event) -> None:
         self.on_error(event, event.transport)

--- a/src/pubtools/sign/clients/msg_send_client.py
+++ b/src/pubtools/sign/clients/msg_send_client.py
@@ -35,13 +35,13 @@ class _SendClient(_MsgClient):
         self.confirmed = 0
         self.total = len(messages)
 
-    def on_start(self, event):
+    def on_start(self, event: proton.Event) -> None:
         conn = event.container.connect(
             urls=self.broker_urls, ssl_domain=self.ssl_domain, sasl_enabled=False
         )
         self.sender = event.container.create_sender(conn)
 
-    def on_sendable(self, event):
+    def on_sendable(self, event: proton.Event) -> None:
         LOG.debug("Sender on_sendable")
         if self.sent < self.total:
             message = self.messages[self.sent]
@@ -55,14 +55,14 @@ class _SendClient(_MsgClient):
             )
             self.sent += 1
 
-    def on_accepted(self, event):
+    def on_accepted(self, event: proton.Event) -> None:
         LOG.debug("Sender accepted")
         self.confirmed += 1
         if self.confirmed == self.total:
             LOG.debug("Sender closing")
             event.connection.close()
 
-    def on_disconnected(self, event):  # pragma: no cover
+    def on_disconnected(self, event: proton.Event) -> None:  # pragma: no cover
         self.sent = self.confirmed  # pragma: no cover
 
 
@@ -99,7 +99,7 @@ class SendClient(Container):
         self._errors = errors
         super().__init__(self.handler)
 
-    def run(self):
+    def run(self) -> List[MsgError]:
         """Run the SendClient."""
         errors_len = 0
         if not len(self.messages):

--- a/src/pubtools/sign/conf/conf.py
+++ b/src/pubtools/sign/conf/conf.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import marshmallow as ma
 from piny import MarshmallowValidator, StrictMatcher, YamlLoader
 
@@ -45,13 +47,13 @@ class ConfigSchema(ma.Schema):
     cosign_signer = ma.fields.Nested(CosignSignerSchema)
 
 
-def load_config(fname: str):
+def load_config(fname: str) -> Any:
     """Load configuration from a filename.
 
     :param fname: filename
     :type fname: str
 
-    :return Dict[str, Any]:
+    :return Any:
     """
     config = YamlLoader(
         path=fname,

--- a/src/pubtools/sign/operations/__init__.py
+++ b/src/pubtools/sign/operations/__init__.py
@@ -4,3 +4,5 @@ from __future__ import annotations
 
 from .clearsign import ClearSignOperation
 from .containersign import ContainerSignOperation
+
+__all__ = ["ClearSignOperation", "ContainerSignOperation"]

--- a/src/pubtools/sign/operations/base.py
+++ b/src/pubtools/sign/operations/base.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from abc import ABC
 
 from dataclasses import dataclass
-from typing import ClassVar, Dict, Any
+from typing import ClassVar, Dict, Any, Type
+from typing_extensions import Self
 
 from ..results.operation_result import OperationResult
 
@@ -13,9 +14,11 @@ class SignOperation(ABC):
     """SignOperation Abstract class."""
 
     ResultType: ClassVar[OperationResult]
+    signing_key: str
+    repo: str
 
     @classmethod
-    def doc_arguments(cls: SignOperation) -> Dict[str, Any]:
+    def doc_arguments(cls: Type[Self]) -> Dict[str, Any]:
         """Return dictionary with arguments description of the operation."""
         doc_arguments = {}
         options_arguments_doc = {}

--- a/src/pubtools/sign/results/__init__.py
+++ b/src/pubtools/sign/results/__init__.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import dataclasses
+from typing import Any, Dict
 
 from .clearsign import ClearSignResult  # noqa: F401
 from .containersign import ContainerSignResult  # noqa: F401
+
+__all__ = ["ClearSignResult", "ContainerSignResult"]
 
 
 @dataclasses.dataclass()
 class SignerResults(ABC):
     """SignerResults abstract class."""
 
+    status: str
+    error_message: str
+
     @abstractmethod
-    def to_dict(self: SignerResults):
+    def to_dict(self: SignerResults) -> Dict[Any, Any]:
         """Return dict representation of SignerResults."""
         ...  # pragma: no cover

--- a/src/pubtools/sign/results/clearsign.py
+++ b/src/pubtools/sign/results/clearsign.py
@@ -1,9 +1,7 @@
-from typing import List
+from typing import List, Dict, Any, Type
 from typing_extensions import Self
 
 from .operation_result import OperationResult
-
-from typing import Dict, Any
 
 import dataclasses
 
@@ -15,12 +13,12 @@ class ClearSignResult(OperationResult):
     outputs: List[str]
     signing_key: str
 
-    def to_dict(self: Self):
+    def to_dict(self: Self) -> Dict[Any, Any]:
         """Return dict representation of ClearOperationResult."""
         return {"outputs": self.outputs, "signing_key": self.signing_key}
 
     @classmethod
-    def doc_arguments(cls: OperationResult) -> Dict[str, Any]:
+    def doc_arguments(cls: Type[Self]) -> Dict[str, Any]:
         """Return dictionary with arguments description of the operation."""
         doc_arguments = {
             "operation_results": {

--- a/src/pubtools/sign/results/containersign.py
+++ b/src/pubtools/sign/results/containersign.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import dataclasses
 
-from typing import List, ClassVar
+from typing import List, ClassVar, Any, Dict
 from typing_extensions import Self
 
 from ..results.operation_result import OperationResult
@@ -16,6 +16,6 @@ class ContainerSignResult(OperationResult):
     signing_key: str
     failed: bool
 
-    def to_dict(self: Self):
+    def to_dict(self: Self) -> Dict[Any, Any]:
         """Return dict representation of ContainerOperationResult."""
         return {"results": self.results, "signing_key": self.signing_key, "failed": self.failed}

--- a/src/pubtools/sign/results/operation_result.py
+++ b/src/pubtools/sign/results/operation_result.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import dataclasses
+from typing import Any, Dict
 
 
 @dataclasses.dataclass()
 class OperationResult(ABC):
     """OperationResult abstract class."""
 
+    signing_key: str
+
     @abstractmethod
-    def to_dict(self: OperationResult):
+    def to_dict(self: OperationResult) -> Dict[Any, Any]:
         """Return dict representation of OperationResult."""
         ...  # pragma: no cover

--- a/src/pubtools/sign/results/signing_results.py
+++ b/src/pubtools/sign/results/signing_results.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import dataclasses
 
-from typing import ForwardRef
+from typing import TYPE_CHECKING
 
 from pubtools.sign.operations.base import SignOperation
 from pubtools.sign.results import SignerResults
 from pubtools.sign.results.operation_result import OperationResult
 
-
-Signer = ForwardRef("Signer")
+if TYPE_CHECKING:  # pragma: no cover
+    from pubtools.sign.signers import Signer
 
 
 @dataclasses.dataclass

--- a/src/pubtools/sign/signers/__init__.py
+++ b/src/pubtools/sign/signers/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 import dataclasses
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Type
+from typing_extensions import Self
 
 from ..results.signing_results import SigningResults
 from ..operations.base import SignOperation
@@ -21,7 +22,7 @@ class Signer(ABC):
         ...  # pragma: no cover
 
     @abstractmethod
-    def operations(self: Signer) -> List[SignOperation]:
+    def operations(self: Signer) -> List[Type[SignOperation]]:
         """Return list of operations supported by the Signer.
 
         :return: List[SignOperation]
@@ -42,7 +43,7 @@ class Signer(ABC):
     _signer_config_key: str = "cosign_signer"
 
     @classmethod
-    def doc_arguments(cls: Signer) -> Dict[str, Any]:
+    def doc_arguments(cls: Type[Self]) -> Dict[str, Any]:
         """Return dict with arguments decription for the signer.
 
         :return: Dict[str, Any]

--- a/src/pubtools/sign/utils.py
+++ b/src/pubtools/sign/utils.py
@@ -1,11 +1,13 @@
 import datetime
 import subprocess
 import os
+import logging
+from typing import Any, Dict, List, Union
 
 from .conf.conf import CONFIG_PATHS
 
 
-def set_log_level(logger, level):
+def set_log_level(logger: logging.Logger, level: str) -> None:
     """Set log level for provided logger.
 
     :param logger: logger
@@ -18,7 +20,7 @@ def set_log_level(logger, level):
     logger.setLevel(level.upper())
 
 
-def isodate_now():
+def isodate_now() -> str:
     """Return current datetime in ISO-8601.
 
     :return: str
@@ -26,7 +28,7 @@ def isodate_now():
     return datetime.datetime.utcnow().isoformat() + "Z"
 
 
-def run_command(cmd, env=None):
+def run_command(cmd: List[str], env: Union[Dict[str, Any], None] = None) -> Any:
     """Run external command and return Process instance."""
     process = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env
@@ -34,7 +36,7 @@ def run_command(cmd, env=None):
     return process
 
 
-def _get_config_file(config_candidate):
+def _get_config_file(config_candidate: str) -> str:
     if not os.path.exists(config_candidate):
         for config_candidate in CONFIG_PATHS:
             if os.path.exists(os.path.expanduser(config_candidate)):

--- a/tests/test_registry_client.py
+++ b/tests/test_registry_client.py
@@ -21,7 +21,7 @@ def mocked_auth_config_files():
 def test_resolve_authentication(mocked_auth_config_files):
     client = ContainerRegistryClient()
     auth = client.resolve_authentication("registry.example.com/foo/bar:latest")
-    assert auth == ["username", "password"]
+    assert auth == ("username", "password")
 
 
 def test_authenticate_to_registry(mocked_auth_config_files):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,black,flake8,docs,py3-bandit
+envlist = py37,black,flake8,docs,mypy,py3-bandit
 skip_missing_interpreters = true
 isolated_build = True
 
@@ -52,6 +52,14 @@ deps=
     -rrequirements-test.txt
 commands=
     bandit -r . -ll --exclude './.tox'
+
+[testenv:mypy]
+description = mypy checks
+basepython = python3
+deps =
+    -rrequirements-test.txt
+commands =
+    mypy src
 
 [flake8]
 ignore = D100,D104,W503


### PR DESCRIPTION
The mypy checks pass with strict mode enabled. Test environments were updated to 3.11 so that new typing syntax would be recognized. Some minor bug fixes were performed for issues that were detected by mypy. For other issues, where there wasn't an obvious solution, I added TOFIX comments.