### PR TITLE
Fix signing key in claim message

### DIFF
--- a/src/pubtools/sign/signers/msgsigner.py
+++ b/src/pubtools/sign/signers/msgsigner.py
@@ -163,7 +163,7 @@ class MsgSigner(Signer):
         data_attr = "claim_file" if sig_type == SignRequestType.CONTAINER else "data"
         _extra_attrs = extra_attrs or {}
         message = {
-            "sig_key_id": signing_key,
+            "sig_key_id": signing_key[-8:],
             data_attr: claim,
             "request_id": str(uuid.uuid4()),
             "created": isodate_now(),

--- a/tests/test_msg_signer.py
+++ b/tests/test_msg_signer.py
@@ -355,7 +355,7 @@ def test__construct_signing_message(f_config_msg_signer_ok):
             patched_date.return_value = "created-date-Z"
             ret = signer._construct_signing_message("some-claim", "some-signing-key", "repo", {})
             assert ret == {
-                "sig_key_id": "some-signing-key",
+                "sig_key_id": "ning-key",
                 "claim_file": "some-claim",
                 "request_id": "1234-5678-abcd-efgh",
                 "created": "created-date-Z",


### PR DESCRIPTION
RADAS expects a short key.