### PR TITLE
Support identity reference

### DIFF
--- a/src/pubtools/sign/operations/containersign.py
+++ b/src/pubtools/sign/operations/containersign.py
@@ -22,6 +22,9 @@ class ContainerSignOperation(SignOperation):
     task_id: str = field(
         metadata={"description": "Usually pub task id, serves as identifier for in signing request"}
     )
+    identity_references: List[str] = field(
+        metadata={"description": "List of references to sign"}, default_factory=list
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Return a dict representation of the object."""

--- a/src/pubtools/sign/signers/cosignsigner.py
+++ b/src/pubtools/sign/signers/cosignsigner.py
@@ -274,7 +274,6 @@ class CosignSigner(Signer):
                     identity_args[f"{repo}@{digest}"] = ["--sign-container-identity", identity]
 
         for ref, args in ref_args.items():
-            LOG.info(f"COSIGN ARGS: {common_args + args}")
             _identity_args = identity_args.get(ref, [])
             outputs[ref] = run_command(
                 common_args + _identity_args + args, env=env_vars, tries=self.retries

--- a/src/pubtools/sign/signers/cosignsigner.py
+++ b/src/pubtools/sign/signers/cosignsigner.py
@@ -362,7 +362,7 @@ def cosign_container_sign(
     signing_result = cosign_signer.sign(operation)
     return {
         "signer_result": signing_result.signer_results.to_dict(),
-        "operation_results": signing_result.operation_result.results,  # type: ignore
+        "operation_results": signing_result.operation_result.results,
         "operation": signing_result.operation.to_dict(),
         "signing_key": signing_result.operation_result.signing_key,
     }

--- a/src/pubtools/sign/signers/msgsigner.py
+++ b/src/pubtools/sign/signers/msgsigner.py
@@ -641,7 +641,7 @@ def msg_container_sign(
     signing_result = msg_signer.sign(operation)
     return {
         "signer_result": signing_result.signer_results.to_dict(),
-        "operation_results": signing_result.operation_result.results,  # type: ignore
+        "operation_results": signing_result.operation_result.results,
         "operation": signing_result.operation.to_dict(),
         "signing_key": signing_result.operation_result.signing_key,
     }

--- a/tests/test_sign_operations.py
+++ b/tests/test_sign_operations.py
@@ -13,12 +13,14 @@ def test_containersign_operation_doc_argument():
             "task_id": {
                 "description": "Usually pub task id, serves as identifier for in signing request"
             },
+            "identity_references": {"description": "List of references to sign"},
         },
         "examples": {
             "digests": "",
             "references": "",
             "signing_key": "",
             "task_id": "",
+            "identity_references": "",
         },
     }
 


### PR DESCRIPTION
When identity reference is provided it's used for cosign as --sign-container-identity