### PR TITLE
Fix building AppImage failure

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -10,6 +10,7 @@ script:
   # Install icon (every AppImage requires one)
   - touch AppDir/usr/share/icons/hicolor/256x256/apps/app_icon.png
   # Install application and its dependencies
+  - python3.8 -m pip install --upgrade setuptools==70.0.0
   - python3.8 -m pip install --system --ignore-installed --prefix=/usr --root=AppDir pubtools-sign==${VERSION}
 
 AppDir:


### PR DESCRIPTION
Building AppImage failure failed[1] due to the issue https://github.com/pypa/setuptools/issues/4483. Pin setuptools==70.0.0 to avoid it.

[1] https://github.com/release-engineering/pubtools-sign/actions/runs/11395924224/job/31725244282