### PR TITLE
Allow requester to be specific from cli

### DIFF
--- a/src/pubtools/sign/operations/clearsign.py
+++ b/src/pubtools/sign/operations/clearsign.py
@@ -46,9 +46,16 @@ class ClearSignOperation(SignOperation):
             "sample": "repo",
         }
     )
+    requester: str = field(
+        metadata={"description": "Requester of the signing operation"}, default=""
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Return a dict representation of the object."""
         return dict(
-            inputs=self.inputs, signing_key=self.signing_key, task_id=self.task_id, repo=self.repo
+            inputs=self.inputs,
+            signing_key=self.signing_key,
+            task_id=self.task_id,
+            repo=self.repo,
+            requester=self.requester,
         )

--- a/src/pubtools/sign/operations/containersign.py
+++ b/src/pubtools/sign/operations/containersign.py
@@ -25,6 +25,9 @@ class ContainerSignOperation(SignOperation):
     identity_references: List[str] = field(
         metadata={"description": "List of references to sign"}, default_factory=list
     )
+    requester: str = field(
+        metadata={"description": "Requester of the signing operation"}, default=""
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Return a dict representation of the object."""
@@ -33,4 +36,5 @@ class ContainerSignOperation(SignOperation):
             references=self.references,
             signing_key=self.signing_key,
             task_id=self.task_id,
+            requester=self.requester,
         )

--- a/src/pubtools/sign/signers/msgsigner.py
+++ b/src/pubtools/sign/signers/msgsigner.py
@@ -596,11 +596,14 @@ def msg_clear_sign(
     task_id: str = "",
     config_file: str = "",
     repo: str = "",
+    requester: str = "",
 ) -> Dict[str, Any]:
     """Run clearsign operation."""
     msg_signer = MsgSigner()
     config = _get_config_file(config_file)
     msg_signer.load_config(load_config(os.path.expanduser(config)))
+    if requester:
+        msg_signer.creator = requester
 
     str_inputs = []
     for input_ in inputs:
@@ -609,7 +612,7 @@ def msg_clear_sign(
         else:
             str_inputs.append(input_)
     operation = ClearSignOperation(
-        inputs=str_inputs, signing_key=signing_key, task_id=task_id, repo=repo
+        inputs=str_inputs, signing_key=signing_key, task_id=task_id, repo=repo, requester=requester
     )
     signing_result = msg_signer.sign(operation)
     return {
@@ -626,11 +629,14 @@ def msg_container_sign(
     config_file: str = "",
     digest: list[str] = [],
     reference: list[str] = [],
+    requester: Optional[str] = "",
 ) -> Dict[str, Any]:
     """Run containersign operation with cli arguments."""
     msg_signer = MsgSigner()
     config = _get_config_file(config_file)
     msg_signer.load_config(load_config(os.path.expanduser(config)))
+    if requester:
+        msg_signer.creator = requester
 
     operation = ContainerSignOperation(
         digests=digest,
@@ -662,6 +668,13 @@ def msg_container_sign(
     default="INFO",
     help="Set log level",
 )
+@click.option(
+    "--requester",
+    required=False,
+    multiple=False,
+    type=str,
+    help="Use this requester instead one from certificate file.",
+)
 @click.option("--repo", help="Repository reference")
 @click.argument("inputs", nargs=-1)
 def msg_clear_sign_main(
@@ -671,6 +684,7 @@ def msg_clear_sign_main(
     config_file: str = "",
     raw: bool = False,
     log_level: str = "INFO",
+    requester: str = "",
     repo: str = "",
 ) -> None:
     """Entry point method for clearsign operation."""
@@ -685,6 +699,7 @@ def msg_clear_sign_main(
         signing_key=signing_key,
         task_id=task_id,
         repo=repo,
+        requester=requester,
         config_file=config_file,
     )
     if not raw:
@@ -727,6 +742,13 @@ def msg_clear_sign_main(
     type=str,
     help="References which should be signed.",
 )
+@click.option(
+    "--requester",
+    required=False,
+    multiple=False,
+    type=str,
+    help="Use this requester instead one from certificate file.",
+)
 @click.option("--raw", default=False, is_flag=True, help="Print raw output instead of json")
 @click.option(
     "--log-level",
@@ -740,6 +762,7 @@ def msg_container_sign_main(
     config_file: str = "",
     digest: List[str] = [],
     reference: List[str] = [],
+    requester: Optional[str] = "",
     raw: bool = False,
     log_level: str = "INFO",
 ) -> None:
@@ -755,6 +778,7 @@ def msg_container_sign_main(
         config_file=config_file,
         digest=digest,
         reference=reference,
+        requester=requester,
     )
     if not raw:
         click.echo(json.dumps(ret))

--- a/src/pubtools/sign/signers/msgsigner.py
+++ b/src/pubtools/sign/signers/msgsigner.py
@@ -629,7 +629,7 @@ def msg_container_sign(
     config_file: str = "",
     digest: list[str] = [],
     reference: list[str] = [],
-    requester: Optional[str] = "",
+    requester: str = "",
 ) -> Dict[str, Any]:
     """Run containersign operation with cli arguments."""
     msg_signer = MsgSigner()
@@ -643,6 +643,7 @@ def msg_container_sign(
         references=reference,
         signing_key=signing_key,
         task_id=task_id,
+        requester=requester,
     )
     signing_result = msg_signer.sign(operation)
     return {
@@ -762,7 +763,7 @@ def msg_container_sign_main(
     config_file: str = "",
     digest: List[str] = [],
     reference: List[str] = [],
-    requester: Optional[str] = "",
+    requester: str = "",
     raw: bool = False,
     log_level: str = "INFO",
 ) -> None:

--- a/tests/test_msg_signer.py
+++ b/tests/test_msg_signer.py
@@ -53,6 +53,34 @@ def test_msg_container_sign(f_msg_signer, f_config_msg_signer_ok):
     assert result.exit_code == 0, result.output
 
 
+def test_msg_container_sign_requester(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.results = []
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    f_msg_signer.return_value.sign.return_value.operation.to_dict.return_value = {}
+    result = CliRunner().invoke(
+        msg_container_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--digest",
+            "some-digest",
+            "--reference",
+            "some-reference",
+            "--task-id",
+            "1",
+            "--config-file",
+            f_config_msg_signer_ok,
+            "--requester",
+            "test-requester",
+        ],
+    )
+    print(result.stdout)
+    assert result.exit_code == 0, result.output
+
+
 def test_msg_container_sign_error(f_msg_signer, f_config_msg_signer_ok):
     f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
         "status": "error",
@@ -161,6 +189,33 @@ def test_msg_clearsign_sign(f_msg_signer, f_config_msg_signer_ok):
             "test-signing-key",
             "--task-id",
             "1",
+            "--config-file",
+            f_config_msg_signer_ok,
+            "hello world",
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 0, result
+
+
+def test_msg_clearsign_sign_requester(f_msg_signer, f_config_msg_signer_ok):
+    f_msg_signer.return_value.sign.return_value.signer_results.to_dict.return_value = {
+        "status": "ok"
+    }
+    f_msg_signer.return_value.sign.return_value.operation_result.outputs = [
+        ({"i": 456, "msg": {"errors": [], "signed_data": "test"}}, {})
+    ]
+    f_msg_signer.return_value.sign.return_value.operation_result.signing_key = ""
+    f_msg_signer.return_value.sign.return_value.operation.to_dict.return_value = {}
+    result = CliRunner().invoke(
+        msg_clear_sign_main,
+        [
+            "--signing-key",
+            "test-signing-key",
+            "--task-id",
+            "1",
+            "--requester",
+            "test-requester",
             "--config-file",
             f_config_msg_signer_ok,
             "hello world",

--- a/tests/test_sign_operations.py
+++ b/tests/test_sign_operations.py
@@ -9,6 +9,7 @@ def test_containersign_operation_doc_argument():
         "options": {
             "digests": {"description": "List of digest to sign"},
             "references": {"description": "List of references to sign"},
+            "requester": {"description": "Requester of the signing operation"},
             "signing_key": {"description": "Signing key short id which should be used for signing"},
             "task_id": {
                 "description": "Usually pub task id, serves as identifier for in signing request"
@@ -20,6 +21,7 @@ def test_containersign_operation_doc_argument():
             "references": "",
             "signing_key": "",
             "task_id": "",
+            "requester": "",
             "identity_references": "",
         },
     }
@@ -44,11 +46,13 @@ def test_clearsign_operation_doc_argument():
                 "description": "Repository name",
                 "required": "true",
             },
+            "requester": {"description": "Requester of the signing operation"},
         },
         "examples": {
             "inputs": ["input1", "input2"],
             "signing_key": "123",
             "task_id": "1",
+            "requester": "",
             "repo": "repo",
         },
     }
@@ -60,15 +64,27 @@ def test_container_sign_to_dict():
         references=["references"],
         signing_key="sig-key",
         task_id="task-id",
+        requester="requester",
     ).to_dict() == dict(
         digests=["digest"],
         references=["references"],
         signing_key="sig-key",
         task_id="task-id",
+        requester="requester",
     )
 
 
 def test_clear_sign_to_dict():
     assert ClearSignOperation(
-        inputs=["input1"], signing_key="sig-key", task_id="task-id", repo="repo"
-    ).to_dict() == dict(inputs=["input1"], signing_key="sig-key", task_id="task-id", repo="repo")
+        inputs=["input1"],
+        signing_key="sig-key",
+        task_id="task-id",
+        repo="repo",
+        requester="requester",
+    ).to_dict() == dict(
+        inputs=["input1"],
+        signing_key="sig-key",
+        task_id="task-id",
+        repo="repo",
+        requester="requester",
+    )


### PR DESCRIPTION
Request specific from command line will override requester fetched from certificate CN or UID