### PR TITLE
Unlock OTEL instrument package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,9 @@ dependencies = [
     "typing_extensions",
     "ansible-core",
     "pubtools>=1.4.0",
-    "opentelemetry-api==1.20.0",
-    "opentelemetry-sdk==1.20.0",
-    "opentelemetry-exporter-otlp==1.20.0"
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Unlock OpenTelemetry packages to allow newer, patched versions. Version 1.20 is currently locked and has vulnerabilities in multiple CVEs, which are temporarily bypassed in CI. This change enables safer, updated versions and reduces reliance on CVE suppressions.

For more information, please refer to https://issues.redhat.com/browse/CLOUDDST-29025.
